### PR TITLE
Redirect the Comment fetch to HTTPReposioty FindWhere()

### DIFF
--- a/app/Helpers/Collaborator.php
+++ b/app/Helpers/Collaborator.php
@@ -8,7 +8,8 @@ class Collaborator
     public static function isAdmin(array $todo, $userId): bool
     {
         $isAdmin = false;
-        if ($todo['data']['user_id'] == $userId) {
+        // dd($todo);
+        if ($todo['user_id'] == $userId) {
             $isAdmin = true;
         } else {
             foreach ($todo['collaborators'] as $collaborator) {

--- a/app/Http/Controllers/TaskCommentController.php
+++ b/app/Http/Controllers/TaskCommentController.php
@@ -25,7 +25,7 @@ class TaskCommentController extends Controller
 
     public function getCommentsPerTask($taskId)
     {
-        $result = $this->taskCommentService->commentsPerTask('task_id', $taskId);
+        $result = $this->taskCommentService->commentsByKey('task_id', $taskId);
         if ($result['status'] == 200 && isset($result["data"])) {
             return response()->json([
                 'status' => 'success',
@@ -96,7 +96,7 @@ class TaskCommentController extends Controller
 
     public function getCommentPerTodo($todoId)
     {
-        $result = $this->taskCommentService->commentsPerTask('todo_id', $todoId);
+        $result = $this->taskCommentService->commentsByKey('todo_id', $todoId);
         if ($result['status'] == 200 && isset($result["data"])) {
             return response()->json([
                 'status' => 'success',

--- a/app/Services/TaskCommentService.php
+++ b/app/Services/TaskCommentService.php
@@ -13,9 +13,9 @@ class TaskCommentService extends TaskCommentRepository
         return Response::checkAndServe($this->httpRepository->all());
     }
 
-    public function commentsPerTask($key, $data)
+    public function commentsByKey($key, $data)
     {
-        return Response::checkAndServe($this->httpRepository->search($key, $data));
+        return Response::checkAndServe($this->httpRepository->findWhere($key, $data));
     }
 
 

--- a/tests/Feature/Http/AssignUsersTest.php
+++ b/tests/Feature/Http/AssignUsersTest.php
@@ -12,39 +12,39 @@ class AssignUsersTest extends TestCase
 
     protected $todoId = "6154eba27f0874785c51cdf5";
     protected $userId = "614f089fe35bb73a77bc2b77";
+    protected $collaborator_id = "614f089fe35bb73a77bc2bcd";
     protected $requestParam = "?user_id=614f089fe35bb73a77bc2b77&organisation_id=614679ee1a5607b13c00bcb7";
 
 
     public function test_collaborator_is_added_to_a_todo()
     {
         $this->withoutExceptionHandling();
-        $data = ['user_id' => $this->userId, 'admin_status' => '0'];
+
+        $data = ['collaborator_id' => $this->collaborator_id, 'admin_status' => '0'];
         $this->json('PUT', 'api/v1/assign-collaborators/' . $this->todoId . $this->requestParam, $data)
             ->assertStatus(200)
-            ->assertJson([
-                "status" => "success",
-                "type" => "Todo",
+            ->assertJsonStructure([
+                "status",
+                "type",
                 "data" => [
-                    '*'
+                    '_id',
+                    "channel",
+                    "collaborators",
+                    "created_at",
+                    "labels",
+                    "tasks",
+                    "title",
+                    "type",
+                    "user_id"
                 ]
             ]);
     }
 
+    public function test_collaborator_is_removed_from_a_todo()
+    { }
 
-    public function test_required_field_for_adding_collaborators()
-    {
-        $this->withoutExceptionHandling();
-        $this->json('PUT', 'api/v1/assign-collaborators/' . $this->todoId . $this->requestParam, ['Accept' => 'application/json'])
-            ->assertStatus(422)
-            ->assertJson([
-                "message" => "The given data was invalid.",
-                "errors" => [
-                    "user_id" => ["The name field is required."],
-                    "task_id" => ["The email field is required."],
-                    "body" => ["The password field is required."],
-                ]
-            ]);
-    }
+
+
 
     // public function test_collaborator_is_added_to_a_todo()
     // {


### PR DESCRIPTION
Changes:

- Comment fetch methods are now directed to the commentsByKey method in the CommentService class