### PR TITLE
Registered A New Plugin ID

### DIFF
--- a/app/Constants/AppConstants.php
+++ b/app/Constants/AppConstants.php
@@ -4,6 +4,9 @@ namespace App\Constants;
 
 class AppConstants
 {
+    // PLUGIN
+    const PLUGIN_ID = "6169836dfbc5b28d42170c3d";
+
     // RTC Publish Actons
     const ACTION_CREATE = "create";
     const ACTION_UPDATE = "update";

--- a/app/Repositories/HTTP/HTTPRepository.php
+++ b/app/Repositories/HTTP/HTTPRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repositories\HTTP;
 
+use App\Constants\AppConstants;
 use App\Contracts\RepositoryInterface;
 use App\Helpers\HelperFnc;
 use Illuminate\Support\Facades\Config;
@@ -13,7 +14,8 @@ class HTTPRepository implements RepositoryInterface
 
     protected $modelName;
     protected $model;
-    protected $plugin_id = '6138deac99bd9e223a37d8f5';
+    // protected $plugin_id = '6138deac99bd9e223a37d8f5';
+    protected $plugin_id = AppConstants::PLUGIN_ID;
     protected $organisation_id; // = '613a3ac959842c7444fb0240'; // same as $org but let's keep for now
 
     public function __construct($modelName = "")


### PR DESCRIPTION
Re-registered TODO plugin with a fresh ID.

Changes made:
- The Plugin is now abstracted as a constant in the Appconstant file.
- HttpRespository now references the plugin id using the abstract method.